### PR TITLE
docs: in_place explanation

### DIFF
--- a/srt.py
+++ b/srt.py
@@ -264,6 +264,8 @@ def sort_and_reindex(subtitles, start_index=1, in_place=False, skip=True):
     :param int start_index: The index to start from
     :param bool in_place: Whether to modify subs in-place for performance
                           (version <=1.0.0 behaviour)
+                          `https://en.wikipedia.org/wiki/in-place_algorithm
+                          <https://en.wikipedia.org/wiki/in-place_algorithm/>`_.
     :param bool skip: Whether to skip subtitles considered not useful (see
                       above for rules)
     :returns: The sorted subtitles


### PR DESCRIPTION
If we have to link a Wikipedia Page for the an ideal understanding of this parameter (and thus method), it should probably be included in the documentation. Also, so it isn't ambiguous with "in place" in the context of captions.

Reference: **Issue** #69 