### PR TITLE
Fix MutableSequence import for Python 3.10 compatibility

### DIFF
--- a/srt_tools/utils.py
+++ b/srt_tools/utils.py
@@ -6,8 +6,12 @@ import srt
 import logging
 import sys
 import itertools
-import collections
 import os
+
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
 
 PROG_NAME = os.path.basename(sys.argv[0]).replace("-", " ", 1)
 
@@ -175,7 +179,7 @@ def set_basic_args(args):
         else:
             log.debug("%s not in DASH_STREAM_MAP", stream_name)
             if stream is args.input:
-                if isinstance(args.input, collections.MutableSequence):
+                if isinstance(args.input, MutableSequence):
                     for i, input_fn in enumerate(args.input):
                         if input_fn in DASH_STREAM_MAP.values():
                             if stream is args.input:


### PR DESCRIPTION
`MutableSequence` (as well as other ABC classes) is not available inside [`collections`](https://docs.python.org/3/library/collections.html) since Python 3.10.
It is now only available in [`collections.abc`](https://docs.python.org/3/library/collections.abc.html#collections.abc.MutableSequence), which was introduced in Python 3.3.

The test is failing too:
```
(toxenv) senpos@DESKTOP-P2TVBBB:~/workspace/srt$ pytest -v -k test_tools_support --tb=short
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/senpos/workspace/srt/toxenv/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/home/senpos/workspace/srt/.hypothesis/examples')
rootdir: /home/senpos/workspace/srt
plugins: cov-2.12.1, hypothesis-6.36.0
collected 41 items / 40 deselected / 1 selected                                                                                                                                                                

srt_tools/tests/test_srt_tools.py::test_tools_support FAILED                                                                                                                                             [100%]

=================================================================================================== FAILURES ===================================================================================================
______________________________________________________________________________________________ test_tools_support ______________________________________________________________________________________________
srt_tools/tests/test_srt_tools.py:117: in test_tools_support
    assert_supports_all_io_methods(*args)
srt_tools/tests/test_srt_tools.py:57: in assert_supports_all_io_methods
    outputs.append(run_srt_util(cmd + ["-i", in_file]))
srt_tools/tests/test_srt_tools.py:28: in run_srt_util
    raw_out = subprocess.check_output(cmd, shell=shell, env=env)
/usr/lib/python3.10/subprocess.py:420: in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
/usr/lib/python3.10/subprocess.py:524: in run
    raise CalledProcessError(retcode, process.args,
E   subprocess.CalledProcessError: Command '['/home/senpos/workspace/srt/toxenv/bin/python', 'srt_tools/srt-normalise', '-i', '/home/senpos/workspace/srt/srt_tools/tests/files/ascii.srt']' returned non-zero exit status 1.
--------------------------------------------------------------------------------------------- Captured stderr call ---------------------------------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/senpos/workspace/srt/srt_tools/srt-normalise", line 28, in <module>
    main()
  File "/home/senpos/workspace/srt/srt_tools/srt-normalise", line 18, in main
    srt_tools.utils.set_basic_args(args)
  File "/home/senpos/workspace/srt/srt_tools/utils.py", line 178, in set_basic_args
    if isinstance(args.input, collections.MutableSequence):
AttributeError: module 'collections' has no attribute 'MutableSequence'
=========================================================================================== short test summary info ============================================================================================
FAILED srt_tools/tests/test_srt_tools.py::test_tools_support - subprocess.CalledProcessError: Command '['/home/senpos/workspace/srt/toxenv/bin/python', 'srt_tools/srt-normalise', '-i', '/home/senpos/worksp...
======================================================================================= 1 failed, 40 deselected in 0.29s =======================================================================================
```

Since you still support Python 2.7, this is the easiest fix.
Tests are now passing:
```
(venv) senpos@DESKTOP-P2TVBBB:~/workspace/srt$ tox
GLOB sdist-make: /home/senpos/workspace/srt/setup.py
py inst-nodeps: /home/senpos/workspace/srt/.tox/.tmp/package/1/srt-3.5.0.zip
py installed: attrs==21.4.0,coverage==6.2,hypothesis==6.36.0,iniconfig==1.1.1,packaging==21.3,pluggy==1.0.0,py==1.11.0,pyparsing==3.0.7,pytest==6.2.5,pytest-cov==2.12.1,sortedcontainers==2.4.0,srt @ file:///home/senpos/workspace/srt/.tox/.tmp/package/1/srt-3.5.0.zip,toml==0.10.2
py run-test-pre: PYTHONHASHSEED='2796403600'
py run-test: commands[0] | /home/senpos/workspace/srt/venv/bin/python --version
Python 3.10.1
py run-test: commands[1] | pytest
============================================================================================= test session starts ==============================================================================================
platform linux -- Python 3.10.1, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
cachedir: .tox/py/.pytest_cache
rootdir: /home/senpos/workspace/srt
plugins: cov-2.12.1, hypothesis-6.36.0
collected 41 items                                                                                                                                                                                             

srt_tools/tests/test_srt_tools.py .                                                                                                                                                                      [  2%]
tests/test_srt.py ........................................                                                                                                                                               [100%]

============================================================================================= 41 passed in 39.09s ==============================================================================================
___________________________________________________________________________________________________ summary ____________________________________________________________________________________________________
  py: commands succeeded
  congratulations :)
```

We try the `collections.abc` import first, so we do not generate warnings on Python versions 3.3 - 3.9, and [Python 2.7 is used to install `srt` way less frequently](https://pypistats.org/packages/srt).