### PR TITLE
fix: subtitle inequality to None

### DIFF
--- a/srt.py
+++ b/srt.py
@@ -126,7 +126,7 @@ class Subtitle(object):
         return hash(frozenset(vars(self).items()))
 
     def __eq__(self, other):
-        return vars(self) == vars(other)
+        return other and vars(self) == vars(other)
 
     def __lt__(self, other):
         return (self.start, self.end, self.index) < (

--- a/srt.py
+++ b/srt.py
@@ -126,7 +126,7 @@ class Subtitle(object):
         return hash(frozenset(vars(self).items()))
 
     def __eq__(self, other):
-        return other and vars(self) == vars(other)
+        return isinstance(other, Subtitle) and vars(self) == vars(other)
 
     def __lt__(self, other):
         return (self.start, self.end, self.index) < (

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -242,8 +242,9 @@ def test_subtitle_inequality(sub_1):
 
 
 @given(subtitles())
-def test_subtitle_inequality_to_none(sub_1):
+def test_subtitle_inequality_to_non_matching_type(sub_1):
     assert sub_1 != None
+    assert sub_1 != 1
 
 
 @given(subtitles())

--- a/tests/test_srt.py
+++ b/tests/test_srt.py
@@ -242,6 +242,11 @@ def test_subtitle_inequality(sub_1):
 
 
 @given(subtitles())
+def test_subtitle_inequality_to_none(sub_1):
+    assert sub_1 != None
+
+
+@given(subtitles())
 def test_subtitle_from_scratch_equality(subtitle):
     srt_block = subtitle.to_srt()
 


### PR DESCRIPTION
Currently, an attempt to execute
`Subtitle(1,2,3,'q') != None` raises `TypeError: vars() argument must have __dict__ attribute`